### PR TITLE
leaflet@1.3.4 styles

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,8 +13,8 @@
     <!-- leaflet dependencies -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"
-      integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
+      href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
+      integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
       crossorigin=""
     />
     <link


### PR DESCRIPTION
Grab pointer wasn't appearing in Firefox. This PR fixes this.

Task: https://www.pivotaltracker.com/story/show/167041804